### PR TITLE
Unicode & Delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,19 @@ value should be simple and can only contain letters, numbers, dashes and undersc
 although, it may contain other indices, in descending order e.g. `$2?:$1`, not `$1?:$2`.
 
 ### Delimiters
-You may substitute `/` for any delimiter not found within your pattern or formatter,
-even if it is escaped. Pull requests to allow escaped delimiters are always welcome,
-e.g. `xo /(\/dir)/$1\//i` vs. `xo |(/dir)|$1/|i`.
+You may substitute `/` for any delimiter.  If it is found within your pattern
+or formatter it must be escaped.  If it would normally be escaped in your
+pattern or it must be escaped again.
+
+```
+echo 'Hello! My name is C3PO, human cyborg relations.' | xo '|^(\w+)?! my name is (\w+)|$1, $2!|i'
+# =>
+#  Hello, C3PO!
+
+echo 'Hello! My name is C3PO, human cyborg relations.' | xo 'w^(\\w+)?! my name is (\\w+)w$1, $2!wi'
+# =>
+#  Hello, C3PO!
+```
 
 ### Regular expression features
 Please see [Go's regular expression documentation](https://golang.org/pkg/regexp/syntax/)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ although, it may contain other indices, in descending order e.g. `$2?:$1`, not `
 ### Delimiters
 You may substitute `/` for any delimiter.  If it is found within your pattern
 or formatter it must be escaped.  If it would normally be escaped in your
-pattern or it must be escaped again.
+pattern or formatter it must be escaped again.
 
 ```
 echo 'Hello! My name is C3PO, human cyborg relations.' | xo '|^(\w+)?! my name is (\w+)|$1, $2!|i'

--- a/main.go
+++ b/main.go
@@ -138,8 +138,10 @@ func split(str string) ([]string, error) {
 		}
 
 		if r == delim {
-			subs = append(subs, buffer.String())
-			buffer = *new(bytes.Buffer)
+			if buffer.Len() > 0 {
+				subs = append(subs, buffer.String())
+				buffer = *new(bytes.Buffer)
+			}
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -59,9 +59,7 @@ func main() {
 		throw("No matches found")
 	}
 
-	var (
-		fallbacks = make(map[int]string)
-	)
+	fallbacks := make(map[int]string)
 
 	for _, group := range matches {
 		result := format

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func compact(strs []string) []string {
 	return result
 }
 
-// split slices s into all substrings bookened by non-escaped values of the
+// split slices s into all substrings separated by non-escaped values of the
 // first rune and returns a slice of those substrings.
 // It removes one backslash escape from any escaped delimiters.
 func split(str string) ([]string, error) {
@@ -144,6 +144,9 @@ func split(str string) ([]string, error) {
 		}
 
 		buffer.WriteRune(r)
+	}
+	if buffer.Len() > 0 {
+		subs = append(subs, buffer.String())
 	}
 	return subs, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -50,13 +50,14 @@ Luke said, "No. No! That's not true! That's impossible!" in a shocked voice.
 
 func TestSplit(t *testing.T) {
 	tests := map[string][]string{
-		`%bc%b\%%`:   []string{"bc", "b%"},
-		`⌘abc⌘bca⌘`:  []string{"abc", "bca"},
-		`\bc\bc\`:    []string{"bc", "bc"},
-		`\b\\c\bc\`:  []string{`b\c`, `bc`},
-		`\xy\xy`:     []string{"xy"},
-		`[\[xy[xy[`:  []string{"[xy", "xy"},
-		`[\\[xy[xy[`: []string{`\[xy`, "xy"},
+		`%bc%b\%%`:    []string{"bc", "b%"},
+		`⌘abc⌘bca⌘`:   []string{"abc", "bca"},
+		`⌘abc⌘bca⌘\⌘`: []string{"abc", "bca", "⌘"},
+		`\bc\bc\`:     []string{"bc", "bc"},
+		`\b\\c\bc\`:   []string{`b\c`, `bc`},
+		`[\[xy[xy[`:   []string{"[xy", "xy"},
+		`[\\[xy[xy[`:  []string{`\[xy`, "xy"},
+		`[\\[xy[xy[i`: []string{`\[xy`, "xy", "i"},
 	}
 outer:
 	for test, expected := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -48,6 +48,38 @@ Luke said, "No. No! That's not true! That's impossible!" in a shocked voice.
 	shouldExit(t, `xo ///`, 1)
 }
 
+func TestSplit(t *testing.T) {
+	tests := map[string][]string{
+		`%bc%b\%%`:   []string{"bc", "b%"},
+		`⌘abc⌘bca⌘`:  []string{"abc", "bca"},
+		`\bc\bc\`:    []string{"bc", "bc"},
+		`\b\\c\bc\`:  []string{`b\c`, `bc`},
+		`\xy\xy`:     []string{"xy"},
+		`[\[xy[xy[`:  []string{"[xy", "xy"},
+		`[\\[xy[xy[`: []string{`\[xy`, "xy"},
+	}
+outer:
+	for test, expected := range tests {
+		actual, err := split(test)
+		if err != nil {
+			t.Logf("Error on split(%q)\n", test)
+			continue
+		}
+
+		if len(actual) != len(expected) {
+			t.Logf("Test: %q. Actual: %v, Expected: %v\n", test, actual, expected)
+			continue
+		}
+
+		for i := range actual {
+			if actual[i] != expected[i] {
+				t.Logf("Test: %q. Actual: %v, Expected: %v\n", test, actual, expected)
+				continue outer
+			}
+		}
+	}
+}
+
 func execShellCommand(t *testing.T, cmd string) string {
 	out, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -41,10 +41,12 @@ Luke said, "No. No! That's not true! That's impossible!" in a shocked voice.
 	shouldEqual(t, `cat fixtures/romans.txt | xo '/\d\s(\w+).*?to all that are in (\w+),.*?24 \[the (grace)? of ([\w\s]{21})/Romans is a letter written by $1 addressed to the people of $2 about the $3?:gospel of $4./mis'`,
 		`Romans is a letter written by Paul addressed to the people of Rome about the grace of our Lord Jesus Christ.
 `)
+	shouldEqual(t, `echo 'hi' | xo '/(hi)/te\/st/mi'`,
+		`te/st
+`)
 	shouldExit(t, `echo '1' | xo '/^(\s)/$1/'`, 1)
 	shouldExit(t, `echo '1' | xo '/1/'`, 1)
 	shouldExit(t, `echo '1' | xo ///`, 1)
-	shouldExit(t, `echo 'hi' | xo '/(hi)/te\/st/mi'`, 1)
 	shouldExit(t, `xo ///`, 1)
 }
 
@@ -58,6 +60,9 @@ func TestSplit(t *testing.T) {
 		`[\[xy[xy[`:   []string{"[xy", "xy"},
 		`[\\[xy[xy[`:  []string{`\[xy`, "xy"},
 		`[\\[xy[xy[i`: []string{`\[xy`, "xy", "i"},
+		`///`:         []string{},
+		`///a`:        []string{"a"},
+		``:            []string{},
 	}
 outer:
 	for test, expected := range tests {


### PR DESCRIPTION
Adds Unicode support to splitting.

Adds the ability to use escaped delimiters.  e.g. "[\[xy[xy["
